### PR TITLE
Return full results in OAuth1 flow

### DIFF
--- a/plugins/oauth_1_2-legged.js
+++ b/plugins/oauth_1_2-legged.js
@@ -52,10 +52,11 @@ module.exports = {
             }
           });
 
-        next({
-          access_token: response.token,
-          access_secret: response.secret
-        });
+        var result = response.results||{};
+        result.access_token = response.token;
+        result.access_secret = response.secret;
+
+        next(result);
       }
     }
   },

--- a/plugins/oauth_1_3-legged.js
+++ b/plugins/oauth_1_3-legged.js
@@ -77,10 +77,12 @@ module.exports = {
             }
           });
 
-        next({
-          access_token: response.token,
-          access_secret: response.secret
-        });
+
+        var result = response.results||{};
+        result.access_token = response.token;
+        result.access_secret = response.secret;
+
+        next(result);
       }
     }
   },


### PR DESCRIPTION
:wave: 

This might be out of the spec's scope but some servers return more than just access token and secret

Like for example [yahoo's refresh token thing](https://developer.yahoo.com/oauth/guide/oauth-refreshaccesstoken.html)

Essentially without the `oauth_session_handle` parameter I can't automate that process, because otherwise I need to make request to the authorization url again (which requires user interaction in Yahoo's case)

With this fix the result query string for the final callback looks like this (for Yahoo)

``` js
{ oauth_expires_in: '3600',
  oauth_session_handle: '1AMPK7VM5Vbs4yQAOdkBzZs8Z0B9ODS2k9KpL6OvZ3a6SFS.yFQMxmw--',
  oauth_authorization_expires_in: '739295544',
  xoauth_yahoo_guid: 'C6YWVTVM24O4SEGIIDLTWA5NUA',
  access_token: '...',
  access_secret: '...' }
```
